### PR TITLE
Run container with the root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM haproxy:lts-alpine
 
+USER root
 EXPOSE 2375
 ENV ALLOW_RESTARTS=0 \
     AUTH=0 \


### PR DESCRIPTION
Due to changes in how HAProxy handled its base user in containers containing HAProxy 2.4+, we need to run as the root user otherwise the container won't start.